### PR TITLE
Added vagrant box url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   config.vm.box = "chef/ubuntu-14.04"
+  config.vm.box_url = "http://opscode-vagrant-boxes.s3.amazonaws.com/ubuntu10.04-gems.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
Hello,

When i tried to do a vagrant up i realized that i didn't have the vagrant box installed and my vagrant installation did not know from where to download it. So i decided to add the box_url to the Vagrantfile.
Because the box name was chef/ubuntu-10.14 i deduced it was the opscode vagrant box of that ubuntu version.
